### PR TITLE
feat: Vercel で自分用のgithub-readme-stats を Deployして表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,12 @@
 
 ---
 
-<!--
 <p>
-<a href="https://github.com/kotaoue"><img height="140px" src="https://github-readme-stats.vercel.app/api?username=kotaoue&show_icons=true&theme=apprentice" /></a>
-<a href="https://github.com/kotaoue"><img height="140px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=kotaoue&layout=compact&theme=apprentice" /></a><br />
+<a href="https://github.com/kotaoue"><img height="140px" src="https://github-readme-stats-xi-sand-15.vercel.app/api?username=kotaoue&show_icons=true&theme=apprentice" /></a>
+<a href="https://github.com/kotaoue"><img height="140px" src="https://github-readme-stats-xi-sand-15.vercel.app/api/top-langs/?username=kotaoue&layout=compact&theme=apprentice" /></a><!--<br />
 <img src="https://github-profile-trophy.vercel.app/?username=kotaoue&theme=apprentice">
-</p>
 -->
+</p>
 
 [![GitHub Streak](https://streak-stats.demolab.com/?user=kotaoue&theme=apprentice)](https://git.io/streak-stats)
 


### PR DESCRIPTION
https://github.com/anuraghazra/github-readme-stats が 404になること多かったので

- https://github.com/kotaoue/kotaoue/issues/32
- https://github.com/kotaoue/kotaoue/issues/38
- https://github.com/kotaoue/kotaoue/pull/39

で相談して

https://vercel.com/kotaoue-4539s-projects/github-readme-stats で対応


<img width="785" height="370" alt="スクリーンショット 2026-02-28 23 18 37" src="https://github.com/user-attachments/assets/cd9ad53a-9eba-4305-957a-efc049e0dccf" />

な感じで表示できるようになった