### PR TITLE
Document Google Fit GitHub Secrets

### DIFF
--- a/tools/fit/README.md
+++ b/tools/fit/README.md
@@ -28,3 +28,14 @@ go run . -cmd update-pedometer -readme ../../README.md
 3. OAuth2 クライアント作成時にダウンロードした `client_secret.json` を `tools/prepareFit/client_secret.json` に配置
 4. `tools/prepareFit` で `offline` アクセス認証を行い、リフレッシュトークンを取得
 5. 取得した値を GitHub Secrets に登録 (`GOOGLE_FIT_CLIENT_ID`, `GOOGLE_FIT_CLIENT_SECRET`, `GOOGLE_FIT_REFRESH_TOKEN`)
+
+### Secrets に入れる値
+
+`GOOGLE_FIT_CLIENT_ID` と `GOOGLE_FIT_CLIENT_SECRET` は、`client_secret.json` の値をそのまま使います。
+
+- `GOOGLE_FIT_CLIENT_ID`: `installed.client_id`
+- `GOOGLE_FIT_CLIENT_SECRET`: `installed.client_secret`（JSON 全体ではなく文字列1つ）
+- `GOOGLE_FIT_REFRESH_TOKEN`: `python3 main.py` の `REFRESH_TOKEN: ...` に表示された値
+
+`GOOGLE_FIT_REFRESH_TOKEN` は、上記の `client_id` / `client_secret` と同じ OAuth クライアントで発行したものを使ってください。
+クライアントを作り直した場合は、`python3 main.py` を再実行して新しい `REFRESH_TOKEN` を再発行する必要があります。


### PR DESCRIPTION
Update tools/fit/README.md to specify which values should be stored in GitHub Secrets for Google Fit integration. It maps: GOOGLE_FIT_CLIENT_ID = installed.client_id, GOOGLE_FIT_CLIENT_SECRET = installed.client_secret (as a single string), and GOOGLE_FIT_REFRESH_TOKEN = the REFRESH_TOKEN printed by running `python3 main.py`. Notes that the refresh token must be issued for the same OAuth client and that recreating the client requires rerunning `python3 main.py` to obtain a new token.