### PR TITLE
Add Actions Dashboard link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 ## Links
 
 - [x_x: Giving your long posts a surgical x_x treatment.](https://xx-six-phi.vercel.app/)
+- [kotaoue's Actions Dashboard](https://kotaoue.github.io/ActionsDashboard/)
 
 ---
 


### PR DESCRIPTION
Add a link to kotaoue's Actions Dashboard in the Links section of README.md to provide quick access to the project dashboard.